### PR TITLE
[codex] Add inline EPUB reader to ebooks page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "@ngrx/store": "21.1.0",
     "chart.js": "^4.4.4",
     "chartjs-adapter-moment": "^1.0.1",
+    "epubjs": "^0.3.93",
     "ngx-device-detector": "11.0.0",
     "rxjs": "7.8.1",
     "tslib": "2.7.0",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { FileSizePipe } from './pipes/fileSizePipe';
 import { UploadInterceptor } from '@services/upload.interceptor';
 import { ProgressDialogComponent } from './components/view/progress-dialog/progress-dialog.component';
 import { LibgenComponent } from '@components/view/ebooks/libgen/libgen.component';
+import { EbookReaderComponent } from '@components/view/ebooks/ebook-reader/ebook-reader.component';
 import { StatusService } from '@services/status.service';
 import { LazyImgComponent } from './components/view/lazy-img/lazy-img.component';
 import { HealthComponent } from '@components/view/health/health.component';
@@ -64,6 +65,7 @@ import { environment } from '../environments/environment';
     FileSizePipe,
     ProgressDialogComponent,
     LibgenComponent,
+    EbookReaderComponent,
     HealthComponent,
     LazyImgComponent,
   ],

--- a/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.html
+++ b/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.html
@@ -1,0 +1,57 @@
+<mat-card class="reader-shell" appearance="outlined">
+  <mat-card-header class="reader-header">
+    <div class="reader-title-block">
+      <mat-card-title>{{ book?.name }}</mat-card-title>
+      <mat-card-subtitle>{{ book?.author }}</mat-card-subtitle>
+    </div>
+    <button mat-icon-button type="button" aria-label="Close reader" (click)="onClose()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-card-header>
+
+  <mat-card-content class="reader-content">
+    <div class="reader-toolbar">
+      <div class="reader-toolbar-group">
+        <button mat-stroked-button type="button" (click)="goToPreviousPage()">
+          <mat-icon>chevron_left</mat-icon>
+          Previous
+        </button>
+        <button mat-stroked-button type="button" (click)="goToNextPage()">
+          Next
+          <mat-icon>chevron_right</mat-icon>
+        </button>
+      </div>
+
+      <mat-form-field appearance="outline" class="chapter-select" subscriptSizing="dynamic">
+        <mat-label>Chapter</mat-label>
+        <mat-select [value]="chapterHref" (valueChange)="onChapterChange($event)">
+          @for (chapter of chapters; track chapter.href) {
+            <mat-option [value]="chapter.href">{{ chapter.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <div class="reader-progress" [class.reader-progress-empty]="!progressPercent">
+        <span>{{ progressPercent }}%</span>
+      </div>
+    </div>
+
+    @if (loading) {
+      <div class="reader-state reader-loading-overlay">
+        <mat-spinner diameter="36"></mat-spinner>
+        <p>Opening book...</p>
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="reader-state reader-error">
+        <mat-icon>error</mat-icon>
+        <p>{{ errorMessage }}</p>
+      </div>
+    }
+
+    <div class="reader-frame" [class.reader-frame-hidden]="!!errorMessage">
+      <div #viewer class="reader-viewer"></div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.scss
+++ b/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.scss
@@ -1,0 +1,113 @@
+.reader-shell {
+    overflow: hidden;
+}
+
+.reader-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding-bottom: 0;
+}
+
+.reader-title-block {
+    min-width: 0;
+}
+
+.reader-content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    position: relative;
+}
+
+.reader-toolbar {
+    display: grid;
+    grid-template-columns: auto minmax(180px, 320px) auto;
+    gap: 16px;
+    align-items: center;
+}
+
+.reader-toolbar-group {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.chapter-select {
+    width: 100%;
+}
+
+.reader-progress {
+    justify-self: end;
+    min-width: 64px;
+    text-align: right;
+    font-weight: 500;
+    opacity: 0.82;
+}
+
+.reader-progress-empty {
+    opacity: 0.5;
+}
+
+.reader-frame {
+    position: relative;
+    min-height: 70vh;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
+    background:
+        radial-gradient(circle at top, rgba(255, 255, 255, 0.12), transparent 44%),
+        color-mix(in srgb, currentColor 4%, transparent);
+}
+
+.reader-frame-hidden {
+    display: none;
+}
+
+.reader-viewer {
+    height: 70vh;
+    width: 100%;
+}
+
+.reader-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    text-align: center;
+}
+
+.reader-loading-overlay {
+    position: absolute;
+    inset: 92px 24px 24px;
+    min-height: 240px;
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--mat-app-background-color, #101418) 88%, transparent);
+    z-index: 2;
+    backdrop-filter: blur(3px);
+}
+
+.reader-error mat-icon {
+    width: 32px;
+    height: 32px;
+    font-size: 32px;
+}
+
+@media (max-width: 840px) {
+    .reader-toolbar {
+        grid-template-columns: 1fr;
+    }
+
+    .reader-progress {
+        justify-self: start;
+        text-align: left;
+    }
+
+    .reader-frame,
+    .reader-viewer {
+        min-height: 62vh;
+        height: 62vh;
+    }
+}

--- a/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.ts
+++ b/client/src/app/components/view/ebooks/ebook-reader/ebook-reader.component.ts
@@ -1,0 +1,222 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { EbookData } from '@api/models';
+import ePub from 'epubjs';
+
+type EpubBook = any;
+type EpubRendition = any;
+type EpubLocation = { start?: { cfi?: string } };
+
+@Component({
+  selector: 'app-ebook-reader',
+  templateUrl: './ebook-reader.component.html',
+  styleUrls: ['./ebook-reader.component.scss'],
+  standalone: false,
+})
+export class EbookReaderComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @Input() book: EbookData | null = null;
+  @Input() useDarkMode = false;
+  @Output() closeReader = new EventEmitter<void>();
+  @ViewChild('viewer', { static: true }) viewer?: ElementRef<HTMLDivElement>;
+
+  loading = false;
+  errorMessage = '';
+  progressPercent = 0;
+  chapterHref = '';
+  chapters: Array<{ label: string; href: string }> = [];
+  hasGeneratedLocations = false;
+
+  private epubBook?: EpubBook;
+  private rendition?: EpubRendition;
+  private viewReady = false;
+  private currentCfi = '';
+  private resizeObserver?: ResizeObserver;
+
+  ngAfterViewInit() {
+    this.viewReady = true;
+    this.resizeObserver = new ResizeObserver(() => this.rendition?.resize());
+    if (this.viewer?.nativeElement) {
+      this.resizeObserver.observe(this.viewer.nativeElement);
+    }
+    void this.renderCurrentBook();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['useDarkMode'] && this.rendition) {
+      this.applyTheme();
+    }
+    if (changes['book'] && this.viewReady) {
+      void this.renderCurrentBook();
+    }
+  }
+
+  ngOnDestroy() {
+    this.resizeObserver?.disconnect();
+    this.destroyReader();
+  }
+
+  async goToPreviousPage() {
+    await this.rendition?.prev();
+  }
+
+  async goToNextPage() {
+    await this.rendition?.next();
+  }
+
+  async onChapterChange(href: string) {
+    this.chapterHref = href;
+    await this.rendition?.display(href);
+  }
+
+  onClose() {
+    this.closeReader.emit();
+  }
+
+  private async renderCurrentBook() {
+    this.destroyReader();
+    this.errorMessage = '';
+    this.progressPercent = 0;
+    this.chapters = [];
+    this.chapterHref = '';
+    this.hasGeneratedLocations = false;
+
+    if (!this.book?.filePath || !this.viewer?.nativeElement) {
+      return;
+    }
+
+    this.loading = true;
+    try {
+      this.epubBook = ePub(this.book.filePath);
+      this.rendition = this.epubBook.renderTo(this.viewer.nativeElement, {
+        width: '100%',
+        height: '100%',
+        flow: 'scrolled-doc',
+        manager: 'continuous',
+      });
+
+      this.registerEvents();
+      this.registerThemes();
+      this.applyTheme();
+
+      const navigation = await this.epubBook.loaded.navigation;
+      this.chapters = (navigation?.toc || []).map((item: { label: string; href: string }) => ({
+        label: item.label,
+        href: item.href,
+      }));
+
+      await this.epubBook.ready;
+      const savedLocation = this.getStoredLocation();
+      await this.rendition.display(savedLocation || undefined);
+      this.loading = false;
+
+      void this.generateLocations();
+    } catch (error) {
+      console.error(error);
+      this.errorMessage = 'Unable to open this EPUB in the browser.';
+      this.loading = false;
+    }
+  }
+
+  private registerEvents() {
+    this.rendition?.on('relocated', (location: EpubLocation) => {
+      const cfi = location?.start?.cfi || '';
+      if (!cfi) {
+        return;
+      }
+
+      this.currentCfi = cfi;
+      this.storeLocation(cfi);
+
+      if (this.hasGeneratedLocations && this.epubBook?.locations) {
+        const progress = this.epubBook.locations.percentageFromCfi(cfi);
+        this.progressPercent = Number.isFinite(progress) ? Math.round(progress * 100) : 0;
+      }
+    });
+
+    this.rendition?.on('rendered', (_section: unknown, view: { section?: { href?: string } }) => {
+      this.chapterHref = view?.section?.href || this.chapterHref;
+    });
+  }
+
+  private registerThemes() {
+    const themes = this.rendition?.themes;
+    themes?.register('light', {
+      body: {
+        background: '#f7f1e3 !important',
+        color: '#1f1f1f !important',
+      },
+      a: {
+        color: '#22577a !important',
+      },
+      '::selection': {
+        background: '#c8d6e5 !important',
+      },
+    });
+    themes?.register('dark', {
+      body: {
+        background: '#11151c !important',
+        color: '#f5f7fa !important',
+      },
+      a: {
+        color: '#8ecae6 !important',
+      },
+      '::selection': {
+        background: '#3c4f65 !important',
+      },
+    });
+  }
+
+  private applyTheme() {
+    this.rendition?.themes.select(this.useDarkMode ? 'dark' : 'light');
+  }
+
+  private async generateLocations() {
+    try {
+      await this.epubBook?.locations?.generate(1600);
+      this.hasGeneratedLocations = true;
+      if (this.currentCfi && this.epubBook?.locations) {
+        const progress = this.epubBook.locations.percentageFromCfi(this.currentCfi);
+        this.progressPercent = Number.isFinite(progress) ? Math.round(progress * 100) : 0;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  private getStoredLocation() {
+    if (!this.book) {
+      return '';
+    }
+    return localStorage.getItem(this.storageKey()) || '';
+  }
+
+  private storeLocation(cfi: string) {
+    if (!this.book) {
+      return;
+    }
+    localStorage.setItem(this.storageKey(), cfi);
+  }
+
+  private storageKey() {
+    return `ebook-reader-location:${this.book?.id ?? this.book?.filePath ?? 'unknown'}`;
+  }
+
+  private destroyReader() {
+    this.rendition?.destroy();
+    this.epubBook?.destroy?.();
+    this.rendition = undefined;
+    this.epubBook = undefined;
+    this.currentCfi = '';
+    this.hasGeneratedLocations = false;
+  }
+}

--- a/client/src/app/components/view/ebooks/ebooks.component.html
+++ b/client/src/app/components/view/ebooks/ebooks.component.html
@@ -5,6 +5,14 @@
       Library
     </ng-template>
     <div class="content ebooks-page">
+      @if (activeReaderBook) {
+        <app-ebook-reader
+          [book]="activeReaderBook"
+          [useDarkMode]="useDarkMode"
+          (closeReader)="closeReader()"
+        ></app-ebook-reader>
+      }
+
       <mat-card class="library-header" appearance="outlined" @panelMotion>
         <mat-card-header>
           <mat-card-title>Your Library</mat-card-title>
@@ -65,6 +73,11 @@
                   <div class="description" [innerHtml]="ebook.description || 'No description provided.'">
                   </div>
                 </mat-menu>
+                @if (canReadInBrowser(ebook)) {
+                  <button mat-flat-button color="primary" type="button" (click)="openReader(ebook)">
+                    Read
+                  </button>
+                }
                 <button
                   #optionsButton
                   mat-icon-button
@@ -77,6 +90,12 @@
                   </mat-icon>
                 </button>
                 <mat-menu #optionsMenu>
+                  @if (canReadInBrowser(ebook)) {
+                    <button mat-menu-item type="button" (click)="openReader(ebook)">
+                      <mat-icon>auto_stories</mat-icon>
+                      <span>Read in Browser</span>
+                    </button>
+                  }
                   <a mat-menu-item [href]="ebook.filePath">
                     <mat-icon>download</mat-icon>
                     <span>Download</span>
@@ -179,10 +198,21 @@
                 <mat-menu #newspaperDescription>
                   <div class="description" [innerHtml]="newspaper.description || 'No description provided.'"></div>
                 </mat-menu>
+                @if (canReadInBrowser(newspaper)) {
+                  <button mat-flat-button color="primary" type="button" (click)="openReader(newspaper)">
+                    Read
+                  </button>
+                }
                 <button mat-icon-button aria-label="View more" title="More info" [matMenuTriggerFor]="newspaperOptions">
                   <mat-icon>menu</mat-icon>
                 </button>
                 <mat-menu #newspaperOptions>
+                  @if (canReadInBrowser(newspaper)) {
+                    <button mat-menu-item type="button" (click)="openReader(newspaper)">
+                      <mat-icon>auto_stories</mat-icon>
+                      <span>Read in Browser</span>
+                    </button>
+                  }
                   <a mat-menu-item [href]="newspaper.filePath">
                     <mat-icon>download</mat-icon>
                     <span>Download</span>

--- a/client/src/app/components/view/ebooks/ebooks.component.scss
+++ b/client/src/app/components/view/ebooks/ebooks.component.scss
@@ -4,6 +4,10 @@
     gap: 16px;
 }
 
+:host {
+    display: block;
+}
+
 .tab-icon {
     margin-right: 8px;
 }
@@ -64,6 +68,8 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 :host ::ng-deep app-lazy-img.cover-image {

--- a/client/src/app/components/view/ebooks/ebooks.component.ts
+++ b/client/src/app/components/view/ebooks/ebooks.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef, HostListener, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { UiStateActions } from '@actions/ui-state.actions';
+import { UiStateSelectors } from '@selectors/ui-state.selectors';
 import { EbooksService } from '@services/ebooks.service';
 import { EbookData } from '@api/models';
 import { UploadDialogComponent } from '../upload-dialog/upload-dialog.component';
@@ -45,12 +46,14 @@ import {
     ],
     standalone: false
 })
-export class EbooksComponent implements OnInit {
+export class EbooksComponent implements OnInit, OnDestroy {
 
   ebooks: EbookData[] = [];
   filteredEbooks: EbookData[] = [];
   newspapers: EbookData[] = [];
   filteredNewspapers: EbookData[] = [];
+  activeReaderBook: EbookData | null = null;
+  useDarkMode = false;
   subscriptions: Subscription[] = [];
   readonly librarySearchControl = new FormControl('', { nonNullable: true });
   readonly newspaperSearchControl = new FormControl('', { nonNullable: true });
@@ -68,6 +71,7 @@ export class EbooksComponent implements OnInit {
 
   constructor(
     private uiActions: UiStateActions,
+    private uiSelectors: UiStateSelectors,
     private ebooksService: EbooksService,
     private dialog: MatDialog,
     private snackbar: MatSnackBar,
@@ -77,6 +81,9 @@ export class EbooksComponent implements OnInit {
   ngOnInit() {
     this.uiActions.setCurrentApp('Ebooks');
     this.subscriptions = [
+      this.uiSelectors.getUseDarkMode().subscribe(useDarkMode => {
+        this.useDarkMode = useDarkMode;
+      }),
       this.librarySearchControl.valueChanges.pipe(
         debounceTime(120),
         distinctUntilChanged(),
@@ -146,6 +153,21 @@ export class EbooksComponent implements OnInit {
   public onDownload() {
     this.tabs.selectedIndex = 0;
     this.updateEbooks();
+  }
+
+  public canReadInBrowser(ebook: EbookData) {
+    return !!ebook.filePath?.toLowerCase().endsWith('.epub');
+  }
+
+  public openReader(ebook: EbookData) {
+    if (!this.canReadInBrowser(ebook)) {
+      return;
+    }
+    this.activeReaderBook = ebook;
+  }
+
+  public closeReader() {
+    this.activeReaderBook = null;
   }
 
   public clearLibrarySearch() {
@@ -239,6 +261,11 @@ export class EbooksComponent implements OnInit {
       } else if (this.tabs.selectedIndex === 1 && this.newspaperSearchQuery) {
         this.clearNewspaperSearch();
       }
+    }
+
+    if (event.key === 'Escape' && !isTypingTarget && this.activeReaderBook) {
+      event.preventDefault();
+      this.closeReader();
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds an inline EPUB reader to the ebooks page so browser-readable books can be opened directly from the library view.

## What changed
- adds an `epub.js`-backed reader component for inline reading
- adds `Read` actions for EPUB-backed library and newspaper entries
- syncs reader styling to the app dark/light mode
- persists reading position locally per book
- fixes the initial loading hang by keeping the viewer mounted during load and moving location generation after first render

## Why
The ebooks page previously only supported download/manage actions. This change makes EPUB books readable in-browser and aligns the reader theme with the rest of the app.

## Root cause
The first pass hid the reader container with `display: none` while `epub.js` was mounting into it, and it waited on location generation before first display. That left the viewer at `0x0` and kept the loading state stuck.

## Impact
Users can now open EPUB books directly from the library page, read them in the browser, and return later to the saved position.

## Validation
- `npm run build` in `client`
- local smoke test of `/home/ebooks` in headless Chromium
- verified the reader shell opens, EPUB iframes mount, advancing past the cover loads text content, and `Esc` closes the reader