### PR TITLE
[codex] Update deprecated GitHub Actions workflow steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Download server dependencies 
         working-directory: server
-        run: npm ci
+        run: npm install
 
       - name: Download client dependencies 
         working-directory: client
-        run: npm ci
+        run: npm install
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,25 +3,27 @@ name: Build
 # Run this workflow every time a new commit pushed to your repository
 on: push
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   install:
     name: Install dependencies 
     runs-on: ubuntu-24.04-arm 
     steps:
-      - uses: actions/checkout@v2
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION}}
+          node-version-file: .nvmrc
 
       - name: Download server dependencies 
         working-directory: server
-        run: npm install
+        run: npm ci
 
       - name: Download client dependencies 
         working-directory: client
-        run: npm install
+        run: npm ci
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -38,12 +40,10 @@ jobs:
     runs-on: ubuntu-24.04-arm 
     needs: install
     steps:
-      - uses: actions/checkout@v2
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION}}
+          node-version-file: .nvmrc
       - uses: actions/cache@v4
         id: restore-dependencies-cache
         with:
@@ -73,12 +73,10 @@ jobs:
     runs-on: ubuntu-24.04-arm 
     needs: install
     steps:
-      - uses: actions/checkout@v2
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION}}
+          node-version-file: .nvmrc
       - uses: actions/cache@v4
         id: restore-dependencies-cache
         with:
@@ -96,12 +94,10 @@ jobs:
     runs-on: ubuntu-24.04-arm 
     needs: [build, test]
     steps:
-      - uses: actions/checkout@v2
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION}}
+          node-version-file: .nvmrc
       - uses: actions/cache@v4
         id: restore-dependencies-cache
         with:
@@ -118,10 +114,10 @@ jobs:
           key: build-${{ github.sha }}
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: tbhanson96
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build image


### PR DESCRIPTION
## Summary
Replaces deprecated and aging GitHub Actions workflow patterns in `.github/workflows/build.yml` with current supported equivalents.

## What changed
- upgraded `actions/checkout` from `v2` to `v7`
- upgraded `actions/setup-node` from `v2` to `v6`
- replaced deprecated `::set-output` usage by switching to `setup-node`'s `node-version-file: .nvmrc`
- upgraded `docker/login-action` from `v1` to `v4`
- switched package installation steps from `npm install` to `npm ci`
- changed the GHCR login username to `${{ github.actor }}`
- added explicit workflow permissions for repository contents read and packages write

## Why
Several workflow steps were either deprecated outright or pinned to old major versions. This keeps the CI workflow aligned with current GitHub Actions conventions and avoids deprecation warnings.

## Validation
- parsed `.github/workflows/build.yml` successfully with Python YAML parsing
- reviewed the workflow diff to confirm only the targeted replacements were changed

## Sources checked
- official `actions/checkout` README
- official `actions/setup-node` README
- official `docker/login-action` README
- GitHub Actions workflow command documentation