### PR TITLE
[codex] Add sleep dashboard tab

### DIFF
--- a/client/src/app/components/view/health/health.component.html
+++ b/client/src/app/components/view/health/health.component.html
@@ -19,72 +19,75 @@
     </mat-card-content>
   </mat-card>
 
-  <mat-card class="control-card" appearance="outlined">
-    <mat-card-content class="control-layout">
-      <div class="control-group">
-        <mat-form-field appearance="outline" subscriptSizing="dynamic">
-          <mat-label>Date range</mat-label>
-          <mat-date-range-input [rangePicker]="picker">
-            <input matStartDate placeholder="Start date" [(ngModel)]="from">
-            <input matEndDate placeholder="End date" [(ngModel)]="to">
-          </mat-date-range-input>
-          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-          <mat-date-range-picker #picker></mat-date-range-picker>
-        </mat-form-field>
+  <mat-tab-group class="health-tabs" mat-stretch-tabs="false">
+    <mat-tab label="Metrics">
+      <div class="tab-panel">
+        <mat-card class="control-card" appearance="outlined">
+          <mat-card-content class="control-layout">
+            <div class="control-group">
+              <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                <mat-label>Date range</mat-label>
+                <mat-date-range-input [rangePicker]="picker">
+                  <input matStartDate placeholder="Start date" [(ngModel)]="from">
+                  <input matEndDate placeholder="End date" [(ngModel)]="to">
+                </mat-date-range-input>
+                <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+                <mat-date-range-picker #picker></mat-date-range-picker>
+              </mat-form-field>
 
-        <mat-button-toggle-group [(ngModel)]="aggregation" aria-label="Aggregation mode">
-          <mat-button-toggle value="hourly">Hourly</mat-button-toggle>
-          <mat-button-toggle value="daily">Daily</mat-button-toggle>
-        </mat-button-toggle-group>
-      </div>
+              <mat-button-toggle-group [(ngModel)]="aggregation" aria-label="Aggregation mode">
+                <mat-button-toggle value="hourly">Hourly</mat-button-toggle>
+                <mat-button-toggle value="daily">Daily</mat-button-toggle>
+              </mat-button-toggle-group>
+            </div>
 
-      <div class="control-group">
-        <mat-chip-listbox aria-label="Quick date presets">
-          @for (preset of presets; track preset.label) {
-            <mat-chip-option
-              [selected]="activePresetHours === preset.hours"
-              (click)="onPresetSelect(preset.hours)"
-              >
-              {{ preset.label }}
-            </mat-chip-option>
-          }
-        </mat-chip-listbox>
+            <div class="control-group">
+              <mat-chip-listbox aria-label="Quick date presets">
+                @for (preset of presets; track preset.label) {
+                  <mat-chip-option
+                    [selected]="activePresetHours === preset.hours"
+                    (click)="onPresetSelect(preset.hours)"
+                    >
+                    {{ preset.label }}
+                  </mat-chip-option>
+                }
+              </mat-chip-listbox>
 
-        <div class="control-actions">
-          <button mat-flat-button color="primary" (click)="onSearch()">
-            <mat-icon>insights</mat-icon>
-            Refresh Dashboard
-          </button>
-        </div>
-      </div>
-    </mat-card-content>
-  </mat-card>
+              <div class="control-actions">
+                <button mat-flat-button color="primary" (click)="onSearch()">
+                  <mat-icon>insights</mat-icon>
+                  Refresh Dashboard
+                </button>
+              </div>
+            </div>
+          </mat-card-content>
+        </mat-card>
 
-  <mat-card class="metric-picker-card" appearance="outlined">
-    <mat-card-header>
-      <mat-card-title>Metric Explorer</mat-card-title>
-      <mat-card-subtitle>Choose the metrics you want in the dashboard and filter the catalog when the list gets long.</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content class="metric-picker-content">
-      <mat-form-field appearance="outline" class="metric-filter" subscriptSizing="dynamic">
-        <mat-label>Filter metrics</mat-label>
-        <mat-icon matPrefix>search</mat-icon>
-        <input matInput [(ngModel)]="metricFilter" placeholder="Search by metric name or unit">
-      </mat-form-field>
+        <mat-card class="metric-picker-card" appearance="outlined">
+          <mat-card-header>
+            <mat-card-title>Metric Explorer</mat-card-title>
+            <mat-card-subtitle>Choose the metrics you want in the dashboard and filter the catalog when the list gets long.</mat-card-subtitle>
+          </mat-card-header>
+          <mat-card-content class="metric-picker-content">
+            <mat-form-field appearance="outline" class="metric-filter" subscriptSizing="dynamic">
+              <mat-label>Filter metrics</mat-label>
+              <mat-icon matPrefix>search</mat-icon>
+              <input matInput [(ngModel)]="metricFilter" placeholder="Search by metric name or unit">
+            </mat-form-field>
 
-      <mat-chip-listbox class="metric-chip-list" [multiple]="true" aria-label="Available health metrics">
-        @for (metric of filteredCatalog; track metric.name) {
-          <mat-chip-option
-            [selected]="isMetricSelected(metric.name)"
-            (click)="toggleMetric(metric.name)"
-            >
-            {{ formatMetricName(metric.name) }}
-            <span class="chip-suffix">{{ metric.units }}</span>
-          </mat-chip-option>
-        }
-      </mat-chip-listbox>
-    </mat-card-content>
-  </mat-card>
+            <mat-chip-listbox class="metric-chip-list" [multiple]="true" aria-label="Available health metrics">
+              @for (metric of filteredCatalog; track metric.name) {
+                <mat-chip-option
+                  [selected]="isMetricSelected(metric.name)"
+                  (click)="toggleMetric(metric.name)"
+                  >
+                  {{ formatMetricName(metric.name) }}
+                  <span class="chip-suffix">{{ metric.units }}</span>
+                </mat-chip-option>
+              }
+            </mat-chip-listbox>
+          </mat-card-content>
+        </mat-card>
 
   @if (hasCatalog && selectedMetrics.length && dashboard) {
     <div class="stats-grid">
@@ -225,4 +228,169 @@
       </mat-card-content>
     </mat-card>
   }
+      </div>
+    </mat-tab>
+
+    <mat-tab label="Sleep">
+      <div class="tab-panel sleep-panel">
+        <mat-card class="control-card" appearance="outlined">
+          <mat-card-content class="control-layout">
+            <div class="control-group">
+              <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                <mat-label>Sleep date range</mat-label>
+                <mat-date-range-input [rangePicker]="sleepPicker">
+                  <input matStartDate placeholder="Start date" [(ngModel)]="from">
+                  <input matEndDate placeholder="End date" [(ngModel)]="to">
+                </mat-date-range-input>
+                <mat-datepicker-toggle matIconSuffix [for]="sleepPicker"></mat-datepicker-toggle>
+                <mat-date-range-picker #sleepPicker></mat-date-range-picker>
+              </mat-form-field>
+            </div>
+
+            <div class="control-group">
+              <mat-chip-set>
+                <mat-chip>{{ sleepSummary?.recordCount || 0 }} sleep segments</mat-chip>
+                <mat-chip>{{ sleepSummary?.nights?.length || 0 }} nights</mat-chip>
+              </mat-chip-set>
+
+              <div class="control-actions">
+                <button mat-flat-button color="primary" (click)="refreshSleepSummary()">
+                  <mat-icon>bedtime</mat-icon>
+                  Refresh Sleep
+                </button>
+              </div>
+            </div>
+          </mat-card-content>
+        </mat-card>
+
+        @if (sleepSummary?.recordCount) {
+          <div class="stats-grid sleep-stats-grid">
+            <mat-card class="stat-card" appearance="outlined">
+              <mat-card-content>
+                <div class="stat-card-header">
+                  <div>
+                    <h3>Asleep</h3>
+                    <p>{{ sleepSummary?.recordCount || 0 }} staged segments</p>
+                  </div>
+                  <span class="trend-pill">{{ formatPercent(((sleepSummary?.asleepMinutes || 0) / (sleepSummary?.totalMinutes || 1)) * 100) }}</span>
+                </div>
+                <div class="stat-primary">{{ formatDuration(sleepSummary?.asleepMinutes) }}</div>
+                <div class="stat-secondary">Tracked window: {{ formatDuration(sleepSummary?.totalMinutes) }}</div>
+              </mat-card-content>
+            </mat-card>
+
+            <mat-card class="stat-card" appearance="outlined">
+              <mat-card-content>
+                <div class="stat-card-header">
+                  <div>
+                    <h3>Awake</h3>
+                    <p>Interruptions inside sleep window</p>
+                  </div>
+                  <span class="trend-pill">{{ getSleepStageSummary('Awake', sleepSummary?.stageSummaries)?.segmentCount || 0 }} segments</span>
+                </div>
+                <div class="stat-primary">{{ formatDuration(sleepSummary?.awakeMinutes) }}</div>
+                <div class="stat-secondary">First to last: {{ formatDate(sleepSummary?.firstStartDate) }} to {{ formatDate(sleepSummary?.lastEndDate) }}</div>
+              </mat-card-content>
+            </mat-card>
+
+            @if (primarySleepNight) {
+              <mat-card class="stat-card" appearance="outlined">
+                <mat-card-content>
+                  <div class="stat-card-header">
+                    <div>
+                      <h3>{{ formatSleepNightDate(primarySleepNight.date) }}</h3>
+                      <p>Latest sleep night in range</p>
+                    </div>
+                    <span class="trend-pill">{{ primarySleepNight.segmentCount }} segments</span>
+                  </div>
+                  <div class="stat-primary">{{ formatDuration(primarySleepNight.asleepMinutes) }}</div>
+                  <div class="stat-secondary">{{ formatDate(primarySleepNight.startDate) }} to {{ formatDate(primarySleepNight.endDate) }}</div>
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+
+          <mat-card class="sleep-stage-card" appearance="outlined">
+            <mat-card-header>
+              <mat-card-title>Stage Breakdown</mat-card-title>
+              <mat-card-subtitle>Minutes and share of tracked sleep segments in the selected range.</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="sleep-stage-grid">
+                @for (stage of sleepSummary?.stageSummaries || []; track stage.value) {
+                  <div class="sleep-stage-row">
+                    <div class="sleep-stage-label">
+                      <span class="sleep-stage-dot" [ngClass]="getSleepStageClass(stage.value)"></span>
+                      <span>{{ formatSleepStage(stage.value) }}</span>
+                    </div>
+                    <div class="sleep-stage-meter">
+                      <div class="sleep-stage-fill" [ngClass]="getSleepStageClass(stage.value)" [style.width.%]="stage.percentOfWindow"></div>
+                    </div>
+                    <div class="sleep-stage-value">
+                      <strong>{{ formatDuration(stage.totalMinutes) }}</strong>
+                      <span>{{ formatPercent(stage.percentOfWindow) }}</span>
+                    </div>
+                  </div>
+                }
+              </div>
+            </mat-card-content>
+          </mat-card>
+
+          <mat-card class="sleep-timeline-card" appearance="outlined">
+            <mat-card-header>
+              <mat-card-title>Sleep Timeline</mat-card-title>
+              <mat-card-subtitle>Staged sleep segments from first recorded start to last recorded end.</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="sleep-timeline">
+                @for (segment of sleepTimelineSegments; track segment.value + segment.startDate) {
+                  <div
+                    class="sleep-segment"
+                    [ngClass]="getSleepStageClass(segment.value)"
+                    [ngStyle]="getSleepSegmentStyle(segment)"
+                    [matTooltip]="formatSleepStage(segment.value) + ': ' + formatDuration(segment.minutes) + ' from ' + formatDate(segment.startDate) + ' to ' + formatDate(segment.endDate)"
+                  ></div>
+                }
+              </div>
+              <div class="sleep-timeline-axis">
+                <span>{{ formatDate(sleepSummary?.firstStartDate) }}</span>
+                <span>{{ formatDate(sleepSummary?.lastEndDate) }}</span>
+              </div>
+            </mat-card-content>
+          </mat-card>
+
+          <mat-card class="sleep-nights-card" appearance="outlined">
+            <mat-card-header>
+              <mat-card-title>Sleep Nights</mat-card-title>
+              <mat-card-subtitle>Nightly rollups grouped from noon to noon.</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="sleep-night-list">
+                @for (night of sleepSummary?.nights || []; track night.date) {
+                  <div class="sleep-night-row">
+                    <div>
+                      <div class="comparison-title">{{ formatSleepNightDate(night.date) }}</div>
+                      <div class="comparison-helper">{{ formatDate(night.startDate) }} to {{ formatDate(night.endDate) }}</div>
+                    </div>
+                    <div class="sleep-night-values">
+                      <span>{{ formatDuration(night.asleepMinutes) }} asleep</span>
+                      <span>{{ formatDuration(night.awakeMinutes) }} awake</span>
+                    </div>
+                  </div>
+                }
+              </div>
+            </mat-card-content>
+          </mat-card>
+        } @else {
+          <mat-card appearance="outlined">
+            <mat-card-content class="empty-state">
+              <mat-icon class="empty-icon">bedtime_off</mat-icon>
+              <h2>No sleep records in this range</h2>
+              <p>Import sleep data or adjust the date range to show sleep stages, nightly totals, and the timeline.</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>
+    </mat-tab>
+  </mat-tab-group>
 </section>

--- a/client/src/app/components/view/health/health.component.scss
+++ b/client/src/app/components/view/health/health.component.scss
@@ -13,6 +13,17 @@
   box-shadow: var(--mat-app-elevation-shadow-level-1);
 }
 
+.health-tabs {
+  display: block;
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+}
+
 .header-content,
 .metric-picker-content,
 .trend-card-content,
@@ -210,6 +221,109 @@ mat-chip-set {
   line-height: 1.55;
 }
 
+.sleep-stage-grid,
+.sleep-night-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sleep-stage-row,
+.sleep-night-row {
+  display: grid;
+  grid-template-columns: minmax(96px, 0.8fr) minmax(160px, 2fr) minmax(96px, auto);
+  align-items: center;
+  gap: 14px;
+}
+
+.sleep-stage-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.sleep-stage-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.sleep-stage-meter {
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.sleep-stage-fill {
+  height: 100%;
+  border-radius: inherit;
+}
+
+.sleep-stage-value {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  white-space: nowrap;
+}
+
+.sleep-stage-value span {
+  opacity: 0.68;
+}
+
+.sleep-timeline {
+  position: relative;
+  height: 72px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.sleep-segment {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  min-width: 3px;
+}
+
+.sleep-timeline-axis {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  font-size: 0.82rem;
+  opacity: 0.72;
+}
+
+.sleep-night-values {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  white-space: nowrap;
+}
+
+.sleep-stage-inbed {
+  background: #78909c;
+}
+
+.sleep-stage-awake {
+  background: #ef6c00;
+}
+
+.sleep-stage-core {
+  background: #1565c0;
+}
+
+.sleep-stage-deep {
+  background: #4527a0;
+}
+
+.sleep-stage-rem {
+  background: #00838f;
+}
+
 .empty-state {
   display: flex;
   flex-direction: column;
@@ -263,13 +377,30 @@ mat-chip-set {
   }
 
   .comparison-row,
-  .stat-card-header {
+  .stat-card-header,
+  .sleep-stage-row,
+  .sleep-night-row {
     flex-direction: column;
     align-items: flex-start;
   }
 
+  .sleep-stage-row,
+  .sleep-night-row {
+    display: flex;
+  }
+
   .comparison-value {
     text-align: left;
+  }
+
+  .sleep-stage-meter {
+    width: 100%;
+  }
+
+  .sleep-stage-value,
+  .sleep-night-values {
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .control-actions button {

--- a/client/src/app/components/view/health/health.component.ts
+++ b/client/src/app/components/view/health/health.component.ts
@@ -9,6 +9,11 @@ import {
   HealthMetricCatalogItem,
   HealthMetricSummary,
   HealthDashboard,
+  SleepNightSummary,
+  SleepSegment,
+  SleepStage,
+  SleepStageSummary,
+  SleepSummary,
 } from '@models/health-dashboard';
 import { HealthService } from '@services/health.service';
 import { Chart, ChartConfiguration } from 'chart.js/auto';
@@ -50,6 +55,12 @@ type ComparisonRow = {
   helper: string;
 };
 
+type SleepTimelineSegment = SleepSegment & {
+  left: number;
+  width: number;
+  minutes: number;
+};
+
 @Component({
   selector: 'app-health',
   templateUrl: './health.component.html',
@@ -76,6 +87,7 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
   public highlights: Highlight[] = [];
   public deepAnalyses: DeepAnalysis[] = [];
   public comparisonRows: ComparisonRow[] = [];
+  public sleepSummary?: SleepSummary;
   public activePresetHours = 36;
 
   private trendChart?: Chart;
@@ -152,6 +164,31 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
       .reduce((sum, count) => sum + count, 0);
   }
 
+  public get primarySleepNight(): SleepNightSummary | undefined {
+    return this.sleepSummary?.nights[this.sleepSummary.nights.length - 1];
+  }
+
+  public get sleepTimelineSegments(): SleepTimelineSegment[] {
+    if (!this.sleepSummary?.data.length) {
+      return [];
+    }
+
+    const start = new Date(this.sleepSummary.firstStartDate || this.sleepSummary.from).getTime();
+    const end = new Date(this.sleepSummary.lastEndDate || this.sleepSummary.to).getTime();
+    const total = Math.max(1, end - start);
+
+    return this.sleepSummary.data.map((segment) => {
+      const segmentStart = new Date(segment.startDate).getTime();
+      const segmentEnd = new Date(segment.endDate).getTime();
+      return {
+        ...segment,
+        left: Math.max(0, ((segmentStart - start) / total) * 100),
+        width: Math.max(0.5, ((segmentEnd - segmentStart) / total) * 100),
+        minutes: Math.max(0, (segmentEnd - segmentStart) / 60000),
+      };
+    });
+  }
+
   public async loadCatalog(): Promise<void> {
     this.ui.setAppBusy(true);
     try {
@@ -164,6 +201,7 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
         this.highlights = [];
         this.deepAnalyses = [];
         this.comparisonRows = [];
+        await this.refreshSleepSummary();
         return;
       }
 
@@ -171,6 +209,7 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
       this.selectedMetrics = this.pickDefaultMetrics(this.catalog.metrics).map((metric) => metric.name);
       this.selectedMetric = this.selectedMetrics[0] || '';
       await this.refreshDashboard();
+      await this.refreshSleepSummary();
     } finally {
       this.ui.setAppBusy(false);
     }
@@ -184,6 +223,7 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
       this.deepAnalyses = [];
       this.comparisonRows = [];
       this.renderCharts();
+      await this.refreshSleepSummary();
       return;
     }
 
@@ -212,10 +252,21 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
     this.activePresetHours = hours;
     this.applyRelativeRange(hours);
     await this.refreshDashboard();
+    await this.refreshSleepSummary();
   }
 
   public async onSearch(): Promise<void> {
     await this.refreshDashboard();
+    await this.refreshSleepSummary();
+  }
+
+  public async refreshSleepSummary(): Promise<void> {
+    this.ui.setAppBusy(true);
+    try {
+      this.sleepSummary = await this.service.getSleepSummary(this.from, this.to);
+    } finally {
+      this.ui.setAppBusy(false);
+    }
   }
 
   public async toggleMetric(metricName: string): Promise<void> {
@@ -298,6 +349,57 @@ export class HealthComponent implements OnInit, AfterViewInit, OnDestroy {
       day: 'numeric',
       hour: this.aggregation === 'hourly' ? 'numeric' : undefined,
     }).format(new Date(date));
+  }
+
+  public formatDuration(minutes?: number): string {
+    if (minutes === undefined || Number.isNaN(minutes)) {
+      return 'No data';
+    }
+
+    const rounded = Math.round(minutes);
+    const hours = Math.floor(rounded / 60);
+    const remainingMinutes = rounded % 60;
+    if (!hours) {
+      return `${remainingMinutes}m`;
+    }
+    return `${hours}h ${remainingMinutes}m`;
+  }
+
+  public formatPercent(value?: number): string {
+    if (value === undefined || Number.isNaN(value)) {
+      return '0%';
+    }
+    return `${value.toFixed(1)}%`;
+  }
+
+  public formatSleepNightDate(date?: string): string {
+    if (!date) {
+      return 'Unavailable';
+    }
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      weekday: 'short',
+    }).format(new Date(`${date}T12:00:00`));
+  }
+
+  public formatSleepStage(stage: SleepStage): string {
+    return stage === 'InBed' ? 'In Bed' : stage;
+  }
+
+  public getSleepStageClass(stage: SleepStage): string {
+    return `sleep-stage-${stage.toLowerCase()}`;
+  }
+
+  public getSleepSegmentStyle(segment: SleepTimelineSegment): Record<string, string> {
+    return {
+      left: `${segment.left}%`,
+      width: `${segment.width}%`,
+    };
+  }
+
+  public getSleepStageSummary(stage: SleepStage, summaries?: SleepStageSummary[]): SleepStageSummary | undefined {
+    return summaries?.find((summary) => summary.value === stage);
   }
 
   public formatSources(sources: string[]): string {

--- a/client/src/app/models/health-dashboard.ts
+++ b/client/src/app/models/health-dashboard.ts
@@ -42,3 +42,45 @@ export interface HealthDashboard {
   aggregation: HealthAggregation;
   metrics: Record<string, HealthMetricSummary>;
 }
+
+export type SleepStage = 'InBed' | 'Awake' | 'Core' | 'Deep' | 'REM';
+
+export interface SleepSegment {
+  qty?: number;
+  source: string;
+  value: SleepStage;
+  startDate: string;
+  endDate: string;
+}
+
+export interface SleepStageSummary {
+  value: SleepStage;
+  segmentCount: number;
+  totalMinutes: number;
+  percentOfWindow: number;
+}
+
+export interface SleepNightSummary {
+  date: string;
+  startDate: string;
+  endDate: string;
+  segmentCount: number;
+  totalMinutes: number;
+  asleepMinutes: number;
+  awakeMinutes: number;
+  stageSummaries: SleepStageSummary[];
+}
+
+export interface SleepSummary {
+  from: string;
+  to: string;
+  recordCount: number;
+  firstStartDate?: string;
+  lastEndDate?: string;
+  totalMinutes: number;
+  asleepMinutes: number;
+  awakeMinutes: number;
+  stageSummaries: SleepStageSummary[];
+  nights: SleepNightSummary[];
+  data: SleepSegment[];
+}

--- a/client/src/app/services/health.service.ts
+++ b/client/src/app/services/health.service.ts
@@ -6,6 +6,7 @@ import {
   HealthAggregation,
   HealthCatalog,
   HealthDashboard,
+  SleepSummary,
 } from '@models/health-dashboard';
 import { lastValueFrom } from 'rxjs';
 
@@ -56,5 +57,15 @@ export class HealthService {
       from: from.toISOString(),
       to: to.toISOString(),
     }));
+  }
+
+  public async getSleepSummary(from: Date, to: Date): Promise<SleepSummary> {
+    const params = new HttpParams()
+      .set('from', from.toISOString())
+      .set('to', to.toISOString());
+
+    return await lastValueFrom(
+      this.http.get<SleepSummary>('/api/health/sleep/summary', { params }),
+    );
   }
 }

--- a/server/src/health/db-health.service.ts
+++ b/server/src/health/db-health.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Between, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import {
   HealthAggregation,
   HealthCatalogDto,
@@ -11,8 +11,11 @@ import {
   HealthMetricCatalogItemDto,
   HealthMetricSummaryDto,
   SleepDataDto,
+  SleepNightSummaryDto,
+  SleepStageSummaryDto,
+  SleepSummaryDto,
 } from '../models/healthData.dto';
-import { HealthRecord, SleepRecord } from '../models/health';
+import { HealthRecord, SleepRecord, SleepType } from '../models/health';
 import { RawHealthData, RawHealthMetric, RawSleepData, RawSleepMetric } from '../models/rawHealthData';
 import { HealthService } from './health.service';
 import { getSyntheticMetricDefinition, listSyntheticMetricDefinitions } from './synthetic-metrics';
@@ -50,6 +53,11 @@ type ResolvedMetricSeries = {
   name: string;
   units: string;
   data: HealthData[];
+};
+
+type SleepDuration = {
+  record: SleepRecord;
+  minutes: number;
 };
 
 @Injectable()
@@ -108,6 +116,16 @@ export class DbHealthService implements HealthService {
       Max: record.Max,
       date: record.date,
       source: record.source,
+    };
+  }
+
+  private toSleepData(record: SleepRecord) {
+    return {
+      qty: record.qty,
+      source: record.source,
+      value: record.value,
+      startDate: record.startDate,
+      endDate: record.endDate,
     };
   }
 
@@ -183,6 +201,78 @@ export class DbHealthService implements HealthService {
     return aggregation === 'daily'
       ? '%Y-%m-%d 00:00:00.000'
       : '%Y-%m-%d %H:00:00.000';
+  }
+
+  private getSleepDuration(record: SleepRecord, from: Date, to: Date): number {
+    const start = Math.max(new Date(record.startDate).getTime(), from.getTime());
+    const end = Math.min(new Date(record.endDate).getTime(), to.getTime());
+    return Math.max(0, (end - start) / 60000);
+  }
+
+  private getSleepNightKey(record: SleepRecord): string {
+    const nightDate = new Date(new Date(record.startDate).getTime() - (12 * 60 * 60 * 1000));
+    return nightDate.toISOString().slice(0, 10);
+  }
+
+  private isAsleepStage(stage: SleepType): boolean {
+    return ![SleepType.AWAKE, SleepType.IN_BED].includes(stage);
+  }
+
+  private buildSleepStageSummaries(durations: SleepDuration[]): SleepStageSummaryDto[] {
+    const totals = new Map<SleepType, { segmentCount: number; totalMinutes: number }>();
+    const totalMinutes = durations.reduce((sum, duration) => sum + duration.minutes, 0);
+    const stageOrder = [SleepType.IN_BED, SleepType.AWAKE, SleepType.REM, SleepType.CORE, SleepType.DEEP];
+
+    for (const duration of durations) {
+      const current = totals.get(duration.record.value) ?? { segmentCount: 0, totalMinutes: 0 };
+      current.segmentCount += 1;
+      current.totalMinutes += duration.minutes;
+      totals.set(duration.record.value, current);
+    }
+
+    return [...totals.entries()]
+      .sort((left, right) => {
+        const leftIndex = stageOrder.indexOf(left[0]);
+        const rightIndex = stageOrder.indexOf(right[0]);
+        return (leftIndex === -1 ? stageOrder.length : leftIndex) - (rightIndex === -1 ? stageOrder.length : rightIndex);
+      })
+      .map(([value, summary]) => ({
+        value,
+        segmentCount: summary.segmentCount,
+        totalMinutes: summary.totalMinutes,
+        percentOfWindow: totalMinutes ? (summary.totalMinutes / totalMinutes) * 100 : 0,
+      }));
+  }
+
+  private buildSleepNightSummaries(durations: SleepDuration[]): SleepNightSummaryDto[] {
+    const grouped = new Map<string, SleepDuration[]>();
+
+    for (const duration of durations) {
+      const key = this.getSleepNightKey(duration.record);
+      grouped.set(key, [...(grouped.get(key) ?? []), duration]);
+    }
+
+    return [...grouped.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([date, entries]) => {
+        const totalMinutes = entries.reduce((sum, entry) => sum + entry.minutes, 0);
+        const awakeMinutes = entries
+          .filter((entry) => entry.record.value === SleepType.AWAKE)
+          .reduce((sum, entry) => sum + entry.minutes, 0);
+        const asleepMinutes = entries
+          .filter((entry) => this.isAsleepStage(entry.record.value))
+          .reduce((sum, entry) => sum + entry.minutes, 0);
+        return {
+          date,
+          startDate: new Date(Math.min(...entries.map((entry) => new Date(entry.record.startDate).getTime()))),
+          endDate: new Date(Math.max(...entries.map((entry) => new Date(entry.record.endDate).getTime()))),
+          segmentCount: entries.length,
+          totalMinutes,
+          asleepMinutes,
+          awakeMinutes,
+          stageSummaries: this.buildSleepStageSummaries(entries),
+        };
+      });
   }
 
   private mergeHealthDataPoints(
@@ -690,6 +780,55 @@ export class DbHealthService implements HealthService {
       return ret;
     } catch (e: any) {
       this.log.log(`Failed to export sleep data: ${e.message}`);
+      throw e;
+    }
+  }
+
+  public async getSleepSummary(from: Date, to: Date): Promise<SleepSummaryDto> {
+    try {
+      const records = await this.sleepRepository.find({
+        where: {
+          startDate: LessThanOrEqual(to),
+          endDate: MoreThanOrEqual(from),
+        },
+        order: {
+          startDate: 'ASC',
+        },
+      });
+
+      const durations = records
+        .map((record) => ({
+          record,
+          minutes: this.getSleepDuration(record, from, to),
+        }))
+        .filter((duration) => duration.minutes > 0);
+      const totalMinutes = durations.reduce((sum, duration) => sum + duration.minutes, 0);
+      const awakeMinutes = durations
+        .filter((duration) => duration.record.value === SleepType.AWAKE)
+        .reduce((sum, duration) => sum + duration.minutes, 0);
+      const asleepMinutes = durations
+        .filter((duration) => this.isAsleepStage(duration.record.value))
+        .reduce((sum, duration) => sum + duration.minutes, 0);
+
+      return {
+        from,
+        to,
+        recordCount: durations.length,
+        firstStartDate: durations.length
+          ? new Date(Math.min(...durations.map((duration) => new Date(duration.record.startDate).getTime())))
+          : undefined,
+        lastEndDate: durations.length
+          ? new Date(Math.max(...durations.map((duration) => new Date(duration.record.endDate).getTime())))
+          : undefined,
+        totalMinutes,
+        asleepMinutes,
+        awakeMinutes,
+        stageSummaries: this.buildSleepStageSummaries(durations),
+        nights: this.buildSleepNightSummaries(durations),
+        data: durations.map((duration) => this.toSleepData(duration.record)),
+      };
+    } catch (e: any) {
+      this.log.log(`Failed to summarize sleep data: ${e.message}`);
       throw e;
     }
   }

--- a/server/src/health/health.controller.ts
+++ b/server/src/health/health.controller.ts
@@ -15,6 +15,7 @@ import {
   HealthDashboardDto,
   HealthDataDto,
   SleepDataDto,
+  SleepSummaryDto,
 } from '../models/healthData.dto';
 import { RawHealthData } from '../models/rawHealthData';
 import { joinRoutes, routes } from '../routes';
@@ -102,6 +103,19 @@ export class HealthController {
       metrics || [],
       aggregation || 'hourly',
     );
+  }
+
+  @Get('sleep/summary')
+  @UseGuards(JwtOrApiKeyGuard)
+  @ApiOkResponse({ description: 'success', type: SleepSummaryDto })
+  @ApiQuery({ name: 'from', type: Date })
+  @ApiQuery({ name: 'to', type: Date })
+  @ApiUnauthorizedResponse({ description: 'Failed to login' })
+  async getSleepSummary(
+    @Query('from') from: Date,
+    @Query('to') to: Date,
+  ) {
+    return this.healthService.getSleepSummary(from, to);
   }
 
   @Get('sleep')

--- a/server/src/health/health.service.ts
+++ b/server/src/health/health.service.ts
@@ -5,6 +5,7 @@ import {
   HealthDashboardDto,
   HealthDataDto,
   SleepDataDto,
+  SleepSummaryDto,
 } from '../models/healthData.dto';
 import { RawHealthData, RawSleepData } from '../models/rawHealthData';
 
@@ -38,6 +39,10 @@ export class HealthService {
   }
 
   public async getSleepData(from: Date, to: Date): Promise<SleepDataDto> {
+    throw new Error('App module configured incorrectly.');
+  }
+
+  public async getSleepSummary(from: Date, to: Date): Promise<SleepSummaryDto> {
     throw new Error('App module configured incorrectly.');
   }
 }

--- a/server/src/models/healthData.dto.ts
+++ b/server/src/models/healthData.dto.ts
@@ -17,6 +17,24 @@ export class SleepData {
   endDate: Date;
 }
 
+export class SleepStageSummaryDto {
+  value: SleepType;
+  segmentCount: number;
+  totalMinutes: number;
+  percentOfWindow: number;
+}
+
+export class SleepNightSummaryDto {
+  date: string;
+  startDate: Date;
+  endDate: Date;
+  segmentCount: number;
+  totalMinutes: number;
+  asleepMinutes: number;
+  awakeMinutes: number;
+  stageSummaries: SleepStageSummaryDto[];
+}
+
 export class HealthData {
   qty?: number;
   Avg?: number;
@@ -89,5 +107,19 @@ export class HealthDashboardDto {
 }
 
 export class SleepDataDto {
+  data: SleepData[];
+}
+
+export class SleepSummaryDto {
+  from: Date;
+  to: Date;
+  recordCount: number;
+  firstStartDate?: Date;
+  lastEndDate?: Date;
+  totalMinutes: number;
+  asleepMinutes: number;
+  awakeMinutes: number;
+  stageSummaries: SleepStageSummaryDto[];
+  nights: SleepNightSummaryDto[];
   data: SleepData[];
 }

--- a/server/test/health/health-e2e.spec.ts
+++ b/server/test/health/health-e2e.spec.ts
@@ -8,7 +8,8 @@ import { AppModule } from '../../src/app.module';
 import { ApiKeyGuard } from '../../src/auth/apikey.guard';
 import { JwtGuard } from '../../src/auth/jwt.guard';
 import { HealthService } from '../../src/health/health.service';
-import { RawHealthData } from '../../src/models/rawHealthData';
+import { SleepType } from '../../src/models/health';
+import { RawHealthData, RawSleepData } from '../../src/models/rawHealthData';
 import { setupMockFs } from '../mock-helper';
 
 const SAMPLE_HEALTH_DATA: RawHealthData = {
@@ -63,6 +64,37 @@ const SAMPLE_HEALTH_DATA: RawHealthData = {
   },
 };
 
+const SAMPLE_SLEEP_DATA: RawSleepData = {
+  data: {
+    metrics: [
+      {
+        name: 'sleep',
+        units: 'stage',
+        data: [
+          {
+            value: SleepType.CORE,
+            source: 'watch',
+            startDate: new Date('2026-01-02T06:00:00.000Z'),
+            endDate: new Date('2026-01-02T07:30:00.000Z'),
+          },
+          {
+            value: SleepType.AWAKE,
+            source: 'watch',
+            startDate: new Date('2026-01-02T07:30:00.000Z'),
+            endDate: new Date('2026-01-02T07:45:00.000Z'),
+          },
+          {
+            value: SleepType.REM,
+            source: 'watch',
+            startDate: new Date('2026-01-02T07:45:00.000Z'),
+            endDate: new Date('2026-01-02T08:45:00.000Z'),
+          },
+        ],
+      },
+    ],
+  },
+};
+
 describe('HealthController (e2e)', () => {
   let app: INestApplication;
 
@@ -79,6 +111,7 @@ describe('HealthController (e2e)', () => {
     await app.init();
 
     await app.get(HealthService).importHealthData(SAMPLE_HEALTH_DATA);
+    await app.get(HealthService).importSleepData(SAMPLE_SLEEP_DATA);
   });
 
   afterAll(async () => {
@@ -103,6 +136,7 @@ describe('HealthController (e2e)', () => {
     expect(totalEnergy.units).toBe('kcal');
     expect(totalEnergy.latestValue).toBe(2100);
     expect(totalEnergy.recordCount).toBe(4);
+    expect(response.body.sleepRecordCount).toBe(3);
   });
 
   it('GET /api/health returns synthetic metric series', async () => {
@@ -140,5 +174,32 @@ describe('HealthController (e2e)', () => {
     expect(summary.buckets).toHaveLength(2);
     expect(summary.buckets[0].sumValue).toBe(1800);
     expect(summary.buckets[1].sumValue).toBe(2100);
+  });
+
+  it('GET /api/health/sleep/summary aggregates sleep stages and nights', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/api/health/sleep/summary')
+      .query({
+        from: '2026-01-02T06:30:00.000Z',
+        to: '2026-01-02T09:00:00.000Z',
+      })
+      .expect(200);
+
+    expect(response.body.recordCount).toBe(3);
+    expect(response.body.totalMinutes).toBe(135);
+    expect(response.body.asleepMinutes).toBe(120);
+    expect(response.body.awakeMinutes).toBe(15);
+    expect(response.body.stageSummaries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: SleepType.CORE, totalMinutes: 60 }),
+      expect.objectContaining({ value: SleepType.AWAKE, totalMinutes: 15 }),
+      expect.objectContaining({ value: SleepType.REM, totalMinutes: 60 }),
+    ]));
+    expect(response.body.nights).toHaveLength(1);
+    expect(response.body.nights[0]).toEqual(expect.objectContaining({
+      date: '2026-01-01',
+      segmentCount: 3,
+      asleepMinutes: 120,
+      awakeMinutes: 15,
+    }));
   });
 });


### PR DESCRIPTION
## Summary
- add a typed backend sleep summary endpoint for staged sleep records
- add a separate Sleep tab to the health UI with summary cards, stage breakdowns, timeline, and nightly rollups
- cover the sleep summary endpoint in the health e2e test

## Validation
- npm test -- --runInBand test/health/health-e2e.spec.ts
- npm run build:server
- npm run build:client
